### PR TITLE
[refactor] MissionCard 컴포넌트 디자인 수정 및 MainBottomBar 아이콘 크기 조정

### DIFF
--- a/app/src/main/java/com/malharang/app/core/component/MissionCard.kt
+++ b/app/src/main/java/com/malharang/app/core/component/MissionCard.kt
@@ -8,8 +8,8 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
@@ -17,25 +17,27 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.malharang.app.R
 import com.malharang.app.ui.theme.MalHaRangTheme
+import com.malharang.app.ui.theme.MalHaRangTheme.colors
+import com.malharang.app.ui.theme.MalHaRangTheme.typography
 
 @Composable
 fun MissionCard(
     title: String = "Order food",
     description: String = "Learn to order food in Korean",
-    onStartClick: () -> Unit = {},
     onClick: () -> Unit = {}
 ) {
     Box(
         modifier = Modifier
             .fillMaxWidth()
             .shadow(
-                elevation = 6.dp,
+                elevation = 4.dp,
                 shape = RoundedCornerShape(16.dp),
-                clip = false
+                clip = true
             )
-            .background(Color.White, shape = RoundedCornerShape(16.dp))
+            .clip(RoundedCornerShape(16.dp))
+            .background(colors.white, shape = RoundedCornerShape(16.dp))
             .clickable(onClick = onClick)
-            .padding(16.dp)
+            .padding(10.dp)
     ) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
@@ -49,40 +51,40 @@ fun MissionCard(
                     Icon(
                         painter = painterResource(id = R.drawable.img_core_missioncard_leaf),
                         contentDescription = null,
-                        tint = Color(0xFF22C55E),
+                        tint = colors.greenTint,
                         modifier = Modifier
-                            .size(14.dp)
+                            .size(18.dp)
                             .padding(end = 4.dp)
                     )
                     Text(
                         text = title,
                         fontWeight = FontWeight.Bold,
                         fontSize = 16.sp,
-                        color = Color.Black
+                        color = colors.black
                     )
                 }
-
-                Spacer(modifier = Modifier.height(4.dp))
 
                 Text(
                     text = description,
                     fontSize = 12.sp,
-                    color = Color.Gray
+                    color = colors.grayDark
                 )
             }
 
-            Button(
-                onClick = onStartClick,
-                shape = RoundedCornerShape(50),
-                colors = ButtonDefaults.buttonColors(
-                    containerColor = Color(0xFF22C55E),
-                    contentColor = Color.White
-                ),
+            Box(
                 modifier = Modifier
-                    .defaultMinSize(minHeight = 36.dp)
+                    .defaultMinSize(minHeight = 24.dp)
                     .padding(start = 12.dp)
+                    .clip(RoundedCornerShape(30))
+                    .background(colors.greenTint)
+                    .padding(horizontal = 20.dp, vertical = 8.dp),
+                contentAlignment = Alignment.Center
             ) {
-                Text(text = "Start")
+                Text(
+                    text = "Start",
+                    style = typography.bodySmall,
+                    color = colors.white
+                )
             }
         }
     }
@@ -93,8 +95,7 @@ fun MissionCard(
 private fun PreviewMissionCard() {
     MalHaRangTheme {
         MissionCard(
-            onClick = {},
-            onStartClick = {}
+            onClick = {}
         )
     }
 }

--- a/app/src/main/java/com/malharang/app/presentation/screen/home/HomeScreen.kt
+++ b/app/src/main/java/com/malharang/app/presentation/screen/home/HomeScreen.kt
@@ -111,19 +111,19 @@ private fun HomeScreen(
                 Text(
                     text = "\uD83D\uDCCD 현재 위치: $currentLocation",
                     modifier = Modifier
-                        .padding(bottom = 5.dp)
+                        .padding(bottom = 10.dp)
                 )
                 MissionCard() // TODO: MissionCardData 로 전달
 
-                Spacer(modifier = Modifier.height(10.dp))
+                Spacer(modifier = Modifier.height(12.dp))
 
                 MissionCard()
 
-                Spacer(modifier = Modifier.height(10.dp))
+                Spacer(modifier = Modifier.height(12.dp))
 
                 MissionCard()
 
-                Spacer(modifier = Modifier.height(10.dp))
+                Spacer(modifier = Modifier.height(12.dp))
 
                 Image(
                     imageVector = ImageVector.vectorResource(R.drawable.ic_home_chevron_down_24),

--- a/app/src/main/java/com/malharang/app/presentation/screen/main/MainBottomBar.kt
+++ b/app/src/main/java/com/malharang/app/presentation/screen/main/MainBottomBar.kt
@@ -96,7 +96,7 @@ private fun RowScope.MainBottomBarItem(
                 interactionSource = remember { MutableInteractionSource() }
             ),
         horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(2.dp, Alignment.CenterVertically)
+        verticalArrangement = Arrangement.Center
     ) {
         Icon(
             imageVector = if (selected) {
@@ -108,11 +108,11 @@ private fun RowScope.MainBottomBarItem(
             },
             contentDescription = null,
             tint = if (selected) colors.greenDark else colors.greenLight,
-            modifier = Modifier.size(36.dp)
+            modifier = Modifier.size(32.dp)
         )
         Text(
             text = stringResource(tab.title),
-            style = typography.bodyMedium,
+            style = typography.bodySmall,
             color = if (selected) colors.greenDark else colors.greenLight
         )
     }

--- a/app/src/main/java/com/malharang/app/presentation/screen/mission/MissionScreen.kt
+++ b/app/src/main/java/com/malharang/app/presentation/screen/mission/MissionScreen.kt
@@ -68,14 +68,12 @@ private fun MissionScreen(padding: PaddingValues) {
             MissionCard(
                 title = "Order food",
                 description = "Learn to order food in Korean",
-                onClick = {},
-                onStartClick = {}
+                onClick = {}
             )
             MissionCard(
                 title = "Ask for directions",
                 description = "Practice asking for directions",
-                onClick = {},
-                onStartClick = {}
+                onClick = {}
             )
         }
 

--- a/app/src/main/java/com/malharang/app/ui/theme/Color.kt
+++ b/app/src/main/java/com/malharang/app/ui/theme/Color.kt
@@ -24,6 +24,9 @@ val Green = Color(0xFF00AC6D)
 val AndSysGray = Color(0xFF858585)
 val AndSysWhite = Color(0xFFF6F6F8)
 
+// Tint
+val GreenTint = Color(0xFF22C55E)
+
 @Immutable
 data class MalHaRangColors(
     val black: Color,
@@ -34,7 +37,8 @@ data class MalHaRangColors(
     val greenDark: Color,
     val green: Color,
     val andSysGray: Color,
-    val andSysWhite: Color
+    val andSysWhite: Color,
+    val greenTint: Color
 )
 
 val defaultMalHaRangColors = MalHaRangColors(
@@ -46,7 +50,8 @@ val defaultMalHaRangColors = MalHaRangColors(
     greenDark = GreenDark,
     green = Green,
     andSysGray = AndSysGray,
-    andSysWhite = AndSysWhite
+    andSysWhite = AndSysWhite,
+    greenTint = GreenTint
 )
 
 val LocalMalHaRangColorsProvider = staticCompositionLocalOf { defaultMalHaRangColors }


### PR DESCRIPTION
## 📝작업 내용
- MissionCard 컴포넌트 디자인 변경:
    - 그림자 elevation 6dp -> 4dp
    - 모서리 둥글기 16dp -> 12dp
    - 내부 패딩 16dp -> 10dp
    - 아이콘 크기 14dp -> 18dp
    - 버튼 모서리 둥글기 50 -> 30
    - 버튼 높이 36dp -> 24dp
    - 버튼 텍스트 스타일 bodySmall로 변경
    - Tint 색상 추가 및 적용 (GreenTint)
- MainBottomBar 아이콘 크기 36dp -> 32dp로 조정

### 스크린샷

https://github.com/user-attachments/assets/4d121534-fa46-419c-8cbe-7693a04a45f6

## To Reviewer
우선 수정 된사항 바로 머지할게요

## #️⃣연관된 이슈
이슈 번호: #14
